### PR TITLE
empty array elements crash

### DIFF
--- a/src/LangListService.php
+++ b/src/LangListService.php
@@ -55,7 +55,7 @@ class LangListService
 	private function getGroup($locale, $group)
 	{
 		$translations = Lang::getLoader()->load($locale, $group);
-		return array_dot($translations);
+		return array_filter(array_dot($translations));
 	}
 
 	/**
@@ -138,7 +138,7 @@ class LangListService
 		}
 
 		if(in_array($group, $this->dotFiles)) {
-			$translations = array_dot($translations);
+			$translations = array_filter(array_dot($translations));
 		}
 
 		return $translations;


### PR DESCRIPTION
Due to https://github.com/laravel/framework/issues/26308
```
Translations export of all groups - started.


   ErrorException  : Array to string conversion

  at /Users/aidas/Projects/aaa/vendor/highsolutions/laravel-lang-import-export/src/Console/ExportToCsvCommand.php:198
    194| 	private function writeFile()
    195| 	{
    196| 		$data = func_get_args();
    197| 		$output = array_shift($data);
  > 198| 		fputcsv($output, $data, $this->parameters['delimiter'], $this->parameters['enclosure']);
    199| 	}
    200|
    201| 	/**
    202| 	 * Close output file and check if adjust file to Excel format.

  Exception trace:

  1   fputcsv(",", """)
      /Users/aidas/Projects/aaa/vendor/highsolutions/laravel-lang-import-export/src/Console/ExportToCsvCommand.php:198

  2   HighSolutions\LangImportExport\Console\ExportToCsvCommand::writeFile("validation", "attributes", [])
      /Users/aidas/Projects/aaa/vendor/highsolutions/laravel-lang-import-export/src/Console/ExportToCsvCommand.php:179
```