### PR TITLE
Laravel 7.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.6.4",
-        "illuminate/support": "5.*|6.*"
+        "illuminate/support": ">=5"
     },
     "autoload": {
         "psr-4": {
@@ -27,7 +27,6 @@
     },
     "extra": {
         "component": "package",
-        "frameworks": ["Laravel 5.7", "Laravel 5.8", "Laravel 6.0"],
         "laravel": {
             "providers": [
                 "HighSolutions\\LangImportExport\\LangImportExportServiceProvider"


### PR DESCRIPTION
The package still works for laravel 7+ too. So it might be the right decision to require illuminate/support >=5 to support all laravel versions since 5.